### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: microsoft/setup-msbuild@v1.1
+      - name: Build solution
+        run: msbuild NegativeScreen.sln /p:Configuration=Release
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: NegativeScreen-build
+          path: |
+            **/bin/Release/**/*
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build solution on Windows

## Testing
- `msbuild NegativeScreen.sln /p:Configuration=Release` *(fails: command not found)*
- `dotnet build NegativeScreen.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867aa7db5688327b7ca79c9c65ed300