### PR TITLE
Fix workflow netfx step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Update Chocolatey
         run: choco upgrade chocolatey
 
-      - name: Install .NET Framework 4.5.2
-        run: choco install netfx-4.5.2 --no-progress --yes
+      - name: Install .NET Framework 4.8.1
+        run: choco install dotnetfx --version=4.8.1.0-rtw --no-progress --yes
 
       - name: Build x86 Release
         run: msbuild NegativeScreen.sln /p:Configuration=Release /p:Platform=x86


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow step to install .NET Framework using the maintained `dotnetfx` package

## Testing
- `bash create-release.sh` *(fails: missing output binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6867af729d388327be2b4a56fdd140f6