### PR TITLE
Add monitor UI and persist config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.3
       - name: Build solution
@@ -28,4 +32,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: NegativeScreen-x86
-          path: NegativeScreen/bin/x86Release/net9.0-windows/NegativeScreen.exe
+          path: NegativeScreen/bin/x86/Release/NegativeScreen.exe

--- a/NegativeScreen/MonitorSelectionForm.cs
+++ b/NegativeScreen/MonitorSelectionForm.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace NegativeScreen
+{
+    internal class MonitorSelectionForm : Form
+    {
+        private CheckedListBox listBox = new CheckedListBox();
+        private Button okButton = new Button();
+        private Button cancelButton = new Button();
+        private List<string> deviceNames = new List<string>();
+
+        public List<string> Selected { get; private set; }
+
+        public MonitorSelectionForm(List<string> current)
+        {
+            this.Text = "Select monitors";
+            this.Size = new Size(400, 300);
+            listBox.Dock = DockStyle.Top;
+            listBox.Height = 200;
+            int i = 0;
+            foreach (var screen in Screen.AllScreens)
+            {
+                string display = OverlayManager.GetMonitorDetail(screen);
+                listBox.Items.Add(display);
+                deviceNames.Add(screen.DeviceName);
+                if (current.Contains(screen.DeviceName))
+                {
+                    listBox.SetItemChecked(i, true);
+                }
+                i++;
+            }
+            okButton.Text = "OK";
+            okButton.DialogResult = DialogResult.OK;
+            okButton.Dock = DockStyle.Bottom;
+            cancelButton.Text = "Cancel";
+            cancelButton.DialogResult = DialogResult.Cancel;
+            cancelButton.Dock = DockStyle.Bottom;
+            Controls.Add(listBox);
+            Controls.Add(okButton);
+            Controls.Add(cancelButton);
+            this.AcceptButton = okButton;
+            this.CancelButton = cancelButton;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            Selected = new List<string>();
+            for (int i = 0; i < listBox.Items.Count; i++)
+            {
+                if (listBox.GetItemChecked(i))
+                {
+                    Selected.Add(deviceNames[i]);
+                }
+            }
+        }
+    }
+}

--- a/NegativeScreen/NegativeScreen.csproj
+++ b/NegativeScreen/NegativeScreen.csproj
@@ -100,6 +100,8 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Program.cs" />
+    <Compile Include="MonitorSelectionForm.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="OverlayManager.cs">
       <SubType>Form</SubType>

--- a/NegativeScreen/Program.cs
+++ b/NegativeScreen/Program.cs
@@ -18,6 +18,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Windows.Forms;
 
 namespace NegativeScreen
 {
@@ -53,9 +55,23 @@ To avoid known bugs relative to the used APIs, please instead run the 64 bits co
 			//without this call, and with custom DPI settings,
 			//the magnified window is either partially out of the screen,
 			//or blurry, if the transformation scale is forced to 1.
-			NativeMethods.SetProcessDPIAware();
-			OverlayManager manager = new OverlayManager();
-		}
+                        NativeMethods.SetProcessDPIAware();
+
+                        List<string> selected = Settings.LoadSelectedMonitors();
+                        using (var form = new MonitorSelectionForm(selected))
+                        {
+                                if (form.ShowDialog() == DialogResult.OK)
+                                {
+                                        selected = form.Selected;
+                                }
+                                else
+                                {
+                                        return;
+                                }
+                        }
+                        Settings.SaveSelectedMonitors(selected);
+                        OverlayManager manager = new OverlayManager(new List<string>(selected));
+                }
 
 		private static bool IsAnotherInstanceAlreadyRunning()
 		{

--- a/NegativeScreen/Settings.cs
+++ b/NegativeScreen/Settings.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows.Forms;
+
+namespace NegativeScreen
+{
+    static class Settings
+    {
+        private static readonly string ConfigFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.txt");
+
+        public static List<string> LoadSelectedMonitors()
+        {
+            if (File.Exists(ConfigFilePath))
+            {
+                return new List<string>(File.ReadAllLines(ConfigFilePath));
+            }
+            List<string> all = new List<string>();
+            foreach (var screen in Screen.AllScreens)
+            {
+                all.Add(screen.DeviceName);
+            }
+            return all;
+        }
+
+        public static void SaveSelectedMonitors(IEnumerable<string> monitors)
+        {
+            File.WriteAllLines(ConfigFilePath, new List<string>(monitors).ToArray());
+        }
+    }
+}

--- a/README.txt
+++ b/README.txt
@@ -11,18 +11,20 @@ This task is joyfully achieved by inverting the colors of your screen.
 Unlike the Windows Magnifier, which is also capable of such color inversion,
 NegativeScreen was specifically designed to be easy and convenient to use.
 
-It comes without any graphic interface, but dont worry, this only makes it easier to use!
+The application now includes a simple configuration window to choose which monitors are inverted.
 
 
 Features:
 
 Invert screen's colors :)
+Simple UI to select which monitors to invert.
 
 Different inversion modes, including "smart" modes,
 allowing blacks and whites inversion, while keeping colors (about) the sames.
 
 Exit the program from the tray icon menu.
-The tray icon lists monitors by their friendly names.
+Monitors are listed with their friendly names and resolutions to help identify similar displays.
+Selected monitors are remembered across application restarts.
 
 
 Windows Aero must be enabled, or the program won't start.


### PR DESCRIPTION
## Summary
- add simple monitor selection form and Settings helper
- save chosen monitors to `config.txt`
- improve overlay manager to show resolution and support the settings UI
- update workflow to use Node 20 runner and fix x86 artifact path
- document UI features in README

## Testing
- `xbuild NegativeScreen.sln /p:Configuration=Release /p:Platform=x86`

------
https://chatgpt.com/codex/tasks/task_e_686c961c75e883278204cdae5e7f8db2