### PR TITLE
Fix monitor dark mode parsing

### DIFF
--- a/NegativeScreen/NegativeScreen.csproj
+++ b/NegativeScreen/NegativeScreen.csproj
@@ -92,6 +92,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BuiltinMatrices.cs" />

--- a/NegativeScreen/Settings.cs
+++ b/NegativeScreen/Settings.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
+using System.Xml.Linq;
 using System.Windows.Forms;
 using System.Runtime.InteropServices;
 
@@ -45,7 +46,36 @@ namespace NegativeScreen
                         cfg = (Config)xs.Deserialize(fs);
                     }
                 }
-                catch { cfg = null; }
+                catch
+                {
+                    // Attempt to clean up common serialization issues, such as
+                    // a <DarkMode xsi:nil="false" /> element with no value.
+                    try
+                    {
+                        var doc = System.Xml.Linq.XDocument.Load(ConfigPath);
+                        var xsi = "http://www.w3.org/2001/XMLSchema-instance";
+                        foreach (var dm in doc.Descendants("DarkMode"))
+                        {
+                            var nilAttr = dm.Attribute(System.Xml.Linq.XName.Get("nil", xsi));
+                            if (nilAttr != null && nilAttr.Value == "false" && string.IsNullOrWhiteSpace(dm.Value))
+                            {
+                                // Remove the xsi:nil attribute and default the value to false
+                                nilAttr.Remove();
+                                dm.Value = "false";
+                            }
+                        }
+
+                        using (var reader = new System.IO.StringReader(doc.ToString()))
+                        {
+                            XmlSerializer xs = new XmlSerializer(typeof(Config));
+                            cfg = (Config)xs.Deserialize(reader);
+                        }
+                    }
+                    catch
+                    {
+                        cfg = null;
+                    }
+                }
             }
             if (cfg == null)
             {

--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,8 @@ Selected monitors and windows are remembered across application restarts.
 "Open minimized on startup" preference is also saved.
 Dark mode theme for the settings window.
 Dark mode is enabled by default on first launch.
+Per-monitor dark mode values from the settings file are now correctly parsed,
+even when malformed entries are encountered.
 Press F2 in the monitor list to quickly rename a selected display.
 Tray icon and settings list displays monitor indices for easier identification.
 Settings window temporarily hides overlays so it stays visible on inverted monitors.


### PR DESCRIPTION
## Summary
- handle invalid `DarkMode` values in settings.xml
- add LINQ XML handling
- document per-monitor dark mode parsing in README

## Testing
- `xbuild NegativeScreen.sln /p:Configuration=Release /p:Platform=x86`

------
https://chatgpt.com/codex/tasks/task_e_687787093a348327b842ee8f98c403e5