### PR TITLE
Enable per-monitor DarkMode support

### DIFF
--- a/NegativeScreen/OverlayManager.cs
+++ b/NegativeScreen/OverlayManager.cs
@@ -284,13 +284,19 @@ namespace NegativeScreen
                     SaveCurrentSelection();
 
                     // Create overlays for selected monitors
+                    Config cfg = Settings.Load();
                     foreach (var screen in Screen.AllScreens)
                     {
                         string monitorId = Settings.GetMonitorId(screen);
-                        if (this.selectedMonitors.Contains(screen.DeviceName) || 
+                        if (this.selectedMonitors.Contains(screen.DeviceName) ||
                             this.selectedMonitors.Any(m => m == monitorId))
                         {
-                            overlays.Add(new NegativeOverlay(screen));
+                            var overlay = new NegativeOverlay(screen);
+                            bool? monitorDark = Settings.GetMonitorDarkMode(screen);
+                            bool dark = monitorDark ?? cfg.DarkMode;
+                            BuiltinMatrices.ChangeColorEffect(overlay.HwndMag,
+                                dark ? BuiltinMatrices.Negative : BuiltinMatrices.Identity);
+                            overlays.Add(overlay);
                         }
                     }
 
@@ -299,7 +305,13 @@ namespace NegativeScreen
                     {
                         IntPtr handle = FindWindowByKey(win);
                         if (handle != IntPtr.Zero)
-                            overlays.Add(new NegativeOverlay(handle));
+                        {
+                            var overlay = new NegativeOverlay(handle);
+                            bool dark = cfg.DarkMode;
+                            BuiltinMatrices.ChangeColorEffect(overlay.HwndMag,
+                                dark ? BuiltinMatrices.Negative : BuiltinMatrices.Identity);
+                            overlays.Add(overlay);
+                        }
                     }
 
                     RefreshLoop(overlays);

--- a/NegativeScreen/Settings.cs
+++ b/NegativeScreen/Settings.cs
@@ -35,6 +35,8 @@ namespace NegativeScreen
         public static Config Load()
         {
             Config cfg = null;
+            bool needSave = false;
+
             if (File.Exists(ConfigPath))
             {
                 try
@@ -45,12 +47,18 @@ namespace NegativeScreen
                         cfg = (Config)xs.Deserialize(fs);
                     }
                 }
-                catch { cfg = null; }
+                catch
+                {
+                    cfg = null;
+                    needSave = true;
+                }
             }
+
             if (cfg == null)
             {
                 cfg = new Config();
                 cfg.DarkMode = true;
+                needSave = true;
             }
 
             // Only add all monitors if this is a new config
@@ -80,6 +88,11 @@ namespace NegativeScreen
                 }
             }
 
+            if (needSave)
+            {
+                Save(cfg);
+            }
+
             return cfg;
         }
 
@@ -93,13 +106,18 @@ namespace NegativeScreen
             try
             {
                 XmlSerializer xs = new XmlSerializer(typeof(Config));
+                string dir = Path.GetDirectoryName(ConfigPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
                 using (FileStream fs = new FileStream(ConfigPath, FileMode.Create))
                 {
                     xs.Serialize(fs, config);
                 }
             }
-            catch 
-            { 
+            catch
+            {
                 // Log error if needed
             }
         }

--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,7 @@ Selected monitors and windows are remembered across application restarts.
 "Open minimized on startup" preference is also saved.
 Dark mode theme for the settings window.
 Dark mode is enabled by default on first launch.
+If no settings.xml is found, a default one is created automatically.
 Per-monitor DarkMode flags in the settings file override the global preference.
 Press F2 in the monitor list to quickly rename a selected display.
 Tray icon and settings list displays monitor indices for easier identification.

--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,7 @@ Selected monitors and windows are remembered across application restarts.
 "Open minimized on startup" preference is also saved.
 Dark mode theme for the settings window.
 Dark mode is enabled by default on first launch.
+Per-monitor DarkMode flags in the settings file override the global preference.
 Press F2 in the monitor list to quickly rename a selected display.
 Tray icon and settings list displays monitor indices for easier identification.
 Settings window temporarily hides overlays so it stays visible on inverted monitors.


### PR DESCRIPTION
## Summary
- apply the configured DarkMode setting per monitor
- apply DarkMode to window overlays
- document per-monitor DarkMode feature

## Testing
- `msbuild NegativeScreen.sln /t:Build /p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687787093a348327b842ee8f98c403e5