### PR TITLE
Add automatic settings file creation

### DIFF
--- a/NegativeScreen/Settings.cs
+++ b/NegativeScreen/Settings.cs
@@ -43,6 +43,18 @@ namespace NegativeScreen
                 try
                 {
                     cfg = new Config { DarkMode = true };
+
+                    foreach (var screen in Screen.AllScreens)
+                    {
+                        cfg.Monitors.Add(screen.DeviceName);
+                        cfg.MonitorLabels.Add(new MonitorLabel
+                        {
+                            Device = screen.DeviceName,
+                            Id = GetMonitorId(screen),
+                            Label = OverlayManager.GetMonitorName(screen)
+                        });
+                    }
+
                     XmlSerializer xs = new XmlSerializer(typeof(Config));
                     using (FileStream fs = new FileStream(ConfigPath, FileMode.Create))
                     {

--- a/NegativeScreen/Settings.cs
+++ b/NegativeScreen/Settings.cs
@@ -36,6 +36,26 @@ namespace NegativeScreen
         public static Config Load()
         {
             Config cfg = null;
+
+            // If the settings file does not exist, create a default one first
+            if (!File.Exists(ConfigPath))
+            {
+                try
+                {
+                    cfg = new Config { DarkMode = true };
+                    XmlSerializer xs = new XmlSerializer(typeof(Config));
+                    using (FileStream fs = new FileStream(ConfigPath, FileMode.Create))
+                    {
+                        xs.Serialize(fs, cfg);
+                    }
+                }
+                catch
+                {
+                    // Ignore errors when creating a new config file
+                    cfg = new Config { DarkMode = true };
+                }
+            }
+
             if (File.Exists(ConfigPath))
             {
                 try

--- a/NegativeScreen/Settings.cs
+++ b/NegativeScreen/Settings.cs
@@ -51,7 +51,7 @@ namespace NegativeScreen
                         {
                             Device = screen.DeviceName,
                             Id = GetMonitorId(screen),
-                            Label = OverlayManager.GetMonitorName(screen)
+                            Label = GetMonitorFriendlyName(screen, false)
                         });
                     }
 
@@ -131,14 +131,14 @@ namespace NegativeScreen
                 var ml = cfg.MonitorLabels.Find(m => (!string.IsNullOrEmpty(m.Id) && m.Id == id) || m.Device == screen.DeviceName);
                 if (ml == null)
                 {
-                    cfg.MonitorLabels.Add(new MonitorLabel { Device = screen.DeviceName, Id = id, Label = GetMonitorFriendlyName(screen) });
+                    cfg.MonitorLabels.Add(new MonitorLabel { Device = screen.DeviceName, Id = id, Label = GetMonitorFriendlyName(screen, false) });
                 }
                 else
                 {
                     ml.Device = screen.DeviceName;
                     ml.Id = id;
                     if (string.IsNullOrEmpty(ml.Label))
-                        ml.Label = GetMonitorFriendlyName(screen);
+                        ml.Label = GetMonitorFriendlyName(screen, false);
                 }
             }
 
@@ -172,11 +172,30 @@ namespace NegativeScreen
             {
                 // First check if we have a stored label for this monitor
                 string monitorId = GetMonitorId(screen);
-                var config = Load();
-                var existingLabel = config.MonitorLabels.Find(m => (m.Id == monitorId) || (m.Device == screen.DeviceName));
-                if (existingLabel != null && !string.IsNullOrEmpty(existingLabel.Label))
+                Config config = null;
+                if (useCached && File.Exists(ConfigPath))
                 {
-                    return existingLabel.Label.Trim();
+                    try
+                    {
+                        XmlSerializer xs = new XmlSerializer(typeof(Config));
+                        using (FileStream fs = new FileStream(ConfigPath, FileMode.Open))
+                        {
+                            config = (Config)xs.Deserialize(fs);
+                        }
+                    }
+                    catch
+                    {
+                        config = null;
+                    }
+                }
+
+                if (config != null)
+                {
+                    var existingLabel = config.MonitorLabels.Find(m => (m.Id == monitorId) || (m.Device == screen.DeviceName));
+                    if (existingLabel != null && !string.IsNullOrEmpty(existingLabel.Label))
+                    {
+                        return existingLabel.Label.Trim();
+                    }
                 }
 
                 // Then try to get the friendly name from the monitor's EDID data

--- a/README.txt
+++ b/README.txt
@@ -33,7 +33,7 @@ Dark mode is enabled by default on first launch.
 Per-monitor dark mode values from the settings file are now correctly parsed,
 even when malformed entries are encountered.
 The application now generates a default settings.xml on first run if none exists,
-including monitor labels using each display's friendly name.
+automatically populating monitor labels with each display's friendly name.
 Press F2 in the monitor list to quickly rename a selected display.
 Tray icon and settings list displays monitor indices for easier identification.
 Settings window temporarily hides overlays so it stays visible on inverted monitors.

--- a/README.txt
+++ b/README.txt
@@ -32,7 +32,8 @@ Dark mode theme for the settings window.
 Dark mode is enabled by default on first launch.
 Per-monitor dark mode values from the settings file are now correctly parsed,
 even when malformed entries are encountered.
-The application now generates a default settings.xml on first run if none exists.
+The application now generates a default settings.xml on first run if none exists,
+including monitor labels using each display's friendly name.
 Press F2 in the monitor list to quickly rename a selected display.
 Tray icon and settings list displays monitor indices for easier identification.
 Settings window temporarily hides overlays so it stays visible on inverted monitors.

--- a/README.txt
+++ b/README.txt
@@ -32,6 +32,7 @@ Dark mode theme for the settings window.
 Dark mode is enabled by default on first launch.
 Per-monitor dark mode values from the settings file are now correctly parsed,
 even when malformed entries are encountered.
+The application now generates a default settings.xml on first run if none exists.
 Press F2 in the monitor list to quickly rename a selected display.
 Tray icon and settings list displays monitor indices for easier identification.
 Settings window temporarily hides overlays so it stays visible on inverted monitors.


### PR DESCRIPTION
## Summary
- create a default `settings.xml` file if it doesn't exist before loading
- document automatic settings file creation

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877907d34648327aba62566546369de